### PR TITLE
Better quiering with customisation

### DIFF
--- a/src/main/scala/com/tapad/druid/client/DSL.scala
+++ b/src/main/scala/com/tapad/druid/client/DSL.scala
@@ -10,14 +10,14 @@ object DSL {
   implicit def string2FilterOps(s: String) : FilterOps = FilterOps(s)
 
   case class PostAggStringOps(lhs: String) {
-    def /(rhs: String) = ArithmeticPostAggregation("%s_by_%s".format(lhs, rhs), "/", Seq(FieldAccess(lhs), FieldAccess(rhs)))
-    def *(rhs: String) = ArithmeticPostAggregation("%s_times_%s".format(lhs, rhs), "*", Seq(FieldAccess(lhs), FieldAccess(rhs)))
-    def -(rhs: String) = ArithmeticPostAggregation("%s_minus_%s".format(lhs, rhs), "-", Seq(FieldAccess(lhs), FieldAccess(rhs)))
-    def +(rhs: String) = ArithmeticPostAggregation("%s_plus_%s".format(lhs, rhs), "-", Seq(FieldAccess(lhs), FieldAccess(rhs)))
+    def /(rhs: String) = ArithmeticPostAggregation("%s_by_%s".format(lhs, rhs), "/", Seq(fieldAccess(lhs), fieldAccess(rhs)))
+    def *(rhs: String) = ArithmeticPostAggregation("%s_times_%s".format(lhs, rhs), "*", Seq(fieldAccess(lhs), fieldAccess(rhs)))
+    def -(rhs: String) = ArithmeticPostAggregation("%s_minus_%s".format(lhs, rhs), "-", Seq(fieldAccess(lhs), fieldAccess(rhs)))
+    def +(rhs: String) = ArithmeticPostAggregation("%s_plus_%s".format(lhs, rhs), "-", Seq(fieldAccess(lhs), fieldAccess(rhs)))
   }
 
   implicit def string2PostAggOps(s: String) : PostAggStringOps = PostAggStringOps(s)
-  implicit def string2PostAgg(s: String) : PostAggregationFieldSpec = ArithmeticPostAggregation("no_name", "*", Seq(FieldAccess(s), constant(1)))
+  implicit def string2PostAgg(s: String) : PostAggregationFieldSpec = ArithmeticPostAggregation("no_name", "*", Seq(fieldAccess(s), constant(1)))
   implicit def numericToConstant[T](n: T)(implicit num: Numeric[T]) : ConstantPostAggregation = constant(num.toDouble(n))
 
   case class OrderByStringOps(col: String) {

--- a/src/main/scala/com/tapad/druid/client/DruidClient.scala
+++ b/src/main/scala/com/tapad/druid/client/DruidClient.scala
@@ -37,6 +37,7 @@ case class DruidClient(serverUrl: String)(implicit val executionContext: Executi
 
   def apply(ts: TimeSeriesQuery) : Future[TimeSeriesResponse] = execute(ts.toJson, TimeSeriesResponse.parse)
   def apply(ts: GroupByQuery) : Future[GroupByResponse] = execute(ts.toJson, GroupByResponse.parse)
+  def apply(ts: TopNQuery) : Future[TopNResponse] = execute(ts.toJson, TopNResponse.parse)
 
   def queryTimeSeries(query: String) : Future[TimeSeriesResponse] = {
     Grammar.parser.parseAll(Grammar.parser.timeSeries, query) match {

--- a/src/main/scala/com/tapad/druid/client/DruidClient.scala
+++ b/src/main/scala/com/tapad/druid/client/DruidClient.scala
@@ -60,5 +60,7 @@ case class DruidClient(serverUrl: String)(implicit val executionContext: Executi
     }
   }
 
+  def close() = client.close()
+
 }
 

--- a/src/main/scala/com/tapad/druid/client/Granularity.scala
+++ b/src/main/scala/com/tapad/druid/client/Granularity.scala
@@ -1,12 +1,33 @@
 package com.tapad.druid.client
 
-case class Granularity(name: String)
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+
+import scala.concurrent.duration._
+
+trait Granularity {
+  def toJson: JValue
+}
+
+case class SimpleGranularity(name: String) extends Granularity {
+  def toJson = JString(name)
+}
+
+case class DurationGranularity(duration: FiniteDuration) extends Granularity {
+  def toJson = JObject(
+    "type" -> "duration",
+    "duration" -> duration.toMillis
+  )
+}
+
 object Granularity {
-  val All       = Granularity("all")
-  val Second    = Granularity("second")
-  val Minute    = Granularity("minute")
-  val FifteenMinute = Granularity("fifteen_minute")
-  val ThirtyMinute = Granularity("thirty_minute")
-  val Day       = Granularity("day")
-  val Hour      = Granularity("hour")
+  val All       = SimpleGranularity("all")
+  val Second    = SimpleGranularity("second")
+  val Minute    = SimpleGranularity("minute")
+  val FifteenMinute = SimpleGranularity("fifteen_minute")
+  val ThirtyMinute = SimpleGranularity("thirty_minute")
+  val Day       = SimpleGranularity("day")
+  val Hour      = SimpleGranularity("hour")
+
+  val FiveMinute = DurationGranularity(5.minutes)
 }

--- a/src/main/scala/com/tapad/druid/client/GroupByQuery.scala
+++ b/src/main/scala/com/tapad/druid/client/GroupByQuery.scala
@@ -39,7 +39,7 @@ object GroupByResponse {
         }
         GroupByResponse(data)
       case err @ _ =>
-        throw new IllegalArgumentException("Invalid time series response: " + err)
+        throw new IllegalArgumentException("Invalid time series response:\n" + org.json4s.jackson.prettyJson(err))
     }
   }
 }

--- a/src/main/scala/com/tapad/druid/client/GroupByQuery.scala
+++ b/src/main/scala/com/tapad/druid/client/GroupByQuery.scala
@@ -17,7 +17,7 @@ case class GroupByQuery(source: String,
     JObject(
       "queryType" -> "groupBy",
       "dataSource" -> source,
-      "granularity" -> granularity.name,
+      "granularity" -> granularity.toJson,
       "dimensions" -> dimensions,
       "aggregations" -> aggregate.map(_.toJson),
       "postAggregations" -> postAggregate.map(_.toJson),

--- a/src/main/scala/com/tapad/druid/client/PostAggregation.scala
+++ b/src/main/scala/com/tapad/druid/client/PostAggregation.scala
@@ -1,7 +1,6 @@
 package com.tapad.druid.client
 
 import org.json4s.JsonAST.{JObject, JValue}
-import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 
 trait PostAggregationFieldSpec extends Expression {
@@ -12,20 +11,25 @@ trait PostAggregationFieldSpec extends Expression {
   def +(rhs: PostAggregationFieldSpec) = arith(rhs, "+")
   def -(rhs: PostAggregationFieldSpec) = arith(rhs, "-")
 }
+
 trait PostAggregation extends PostAggregationFieldSpec {
   def as(outputName: String) : PostAggregation
 }
 
 object PostAggregation {
   def constant(value: Double) = ConstantPostAggregation("constant", value)
+  def fieldAccess(aggregatorName: String, outputName: String) = FieldAccess(aggregatorName, outputName)
+  def fieldAccess(aggregatorName: String) = FieldAccess(aggregatorName, aggregatorName)
+}
 
-  case class FieldAccess(fieldName: String) extends PostAggregationFieldSpec {
-    def toJson: JValue = JObject(
-      "type" -> "fieldAccess",
-      "fieldName" -> fieldName
-    )
-  }
+case class FieldAccess(aggregatorName: String, outputName: String) extends PostAggregation {
+  def toJson: JValue = JObject(
+    "type" -> "fieldAccess",
+    "name" -> outputName,
+    "fieldName" -> aggregatorName
+  )
 
+  def as(outputName: String): PostAggregation = copy(outputName = outputName)
 }
 
 case class ConstantPostAggregation(outputName: String, value: Double) extends PostAggregation  {

--- a/src/main/scala/com/tapad/druid/client/TimeSeriesQuery.scala
+++ b/src/main/scala/com/tapad/druid/client/TimeSeriesQuery.scala
@@ -38,7 +38,7 @@ object TimeSeriesResponse {
         }
         TimeSeriesResponse(data)
       case err @ _ =>
-        throw new IllegalArgumentException("Invalid time series response: " + err)
+        throw new IllegalArgumentException("Invalid time series response:\n" + org.json4s.jackson.prettyJson(err))
     }
   }
 }

--- a/src/main/scala/com/tapad/druid/client/TimeSeriesQuery.scala
+++ b/src/main/scala/com/tapad/druid/client/TimeSeriesQuery.scala
@@ -16,7 +16,7 @@ case class TimeSeriesQuery(source: String,
     JObject(
       "queryType" -> "timeseries",
       "dataSource" -> source,
-      "granularity" -> granularity.name,
+      "granularity" -> granularity.toJson,
       "aggregations" -> aggregate.map(_.toJson),
       "postAggregations" -> postAggregate.map(_.toJson),
       "intervals" -> Time.intervalToString(interval),

--- a/src/main/scala/com/tapad/druid/client/TopNQuery.scala
+++ b/src/main/scala/com/tapad/druid/client/TopNQuery.scala
@@ -19,7 +19,7 @@ case class TopNQuery(source: String,
     JObject(
       "queryType" -> "topN",
       "dataSource" -> source,
-      "granularity" -> granularity.name,
+      "granularity" -> granularity.toJson,
       "dimension" -> dimension,
       "threshold" -> threshold,
       "metric" -> metric,

--- a/src/main/scala/com/tapad/druid/client/TopNQuery.scala
+++ b/src/main/scala/com/tapad/druid/client/TopNQuery.scala
@@ -47,7 +47,7 @@ object TopNResponse {
         }
         TopNResponse(data)
       case err @ _ =>
-        throw new IllegalArgumentException("Invalid top N response: " + err)
+        throw new IllegalArgumentException("Invalid top N response:\n" + org.json4s.jackson.prettyJson(err))
     }
   }
 }


### PR DESCRIPTION
This PR propose 5 modifications, three of them are major and important (i.e. you will not make your requests without) and the two others will be just for more easy and comfortable use of library.

So commit  "Add missing method for executing a TopN query" adds apply method to enable call TopN query. Without this method you can just construct the request but not send it.

Commit "Add missing method to close the client" add simple close method to stop program after receiving the response . 

Commit "	Allow to create granularity from a custom duration" adds case classes extended the basic granularity to create json objects using custom duration.

Commit "Rework aggregations to be more coherent with druid documentation" adds possibility to have custom output name in json object, according to a documentation. along with the possibility to explicitly name the output field, we can just keep the input aggregation name for output field.

Commit "Pretty print error msg from druid" adds human reading output for json of error


